### PR TITLE
Fix shovel not digging holes

### DIFF
--- a/data/actions/lib/actions.lua
+++ b/data/actions/lib/actions.lua
@@ -227,10 +227,12 @@ function onUseShovel(player, item, fromPosition, target, toPosition, isHotkey)
 		return false
 	end
 
+	local targetId = target.itemid
 	local groundId = ground:getId()
-	if table.contains(holes, groundId) then
-		ground:transform(groundId + 1)
-		ground:decay()
+
+	if table.contains(holes, targetId) then
+		target:transform(targetId + 1)
+		target:decay()
 		toPosition.z = toPosition.z + 1
 		tile:relocateTo(toPosition)
 
@@ -371,7 +373,7 @@ function onUsePick(player, item, fromPosition, target, toPosition, isHotkey)
 		target:transform(392)
 		target:decay()
 		toPosition:sendMagicEffect(CONST_ME_POFF)
-		
+
 	elseif targetId == 23759 then
 		target:remove()
 		toPosition:sendMagicEffect(CONST_ME_POFF)

--- a/data/actions/scripts/tools/shovel.lua
+++ b/data/actions/scripts/tools/shovel.lua
@@ -1,3 +1,3 @@
-function onUse(cid, item, fromPosition, itemEx, toPosition)
+function onUse(cid, item, fromPosition, target, toPosition)
     return onUseShovel(player, item, fromPosition, target, toPosition, isHotkey)
 end


### PR DESCRIPTION
## shovel.lua
The `shovel.lua` had a typo in the arguments wich invalidates every dig action

## actions.lua

The `onUseShovel` action had an issue in line `233`, it was trying to compre the `groundid` with the hole `itemid` and it was never finding the hole to dig. Plus it was referencing the `targetId` variables in a lot if else cases but the `targetId` was undefined.