### PR TITLE
fix(prey): add bonus reroll count to RequestResourceData

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6716,7 +6716,7 @@ void Game::playerRequestResourceData(uint32_t playerId, ResourceType_t resourceT
 	switch (resourceType) {
 	case RESOURCETYPE_BANK_GOLD: player->sendResourceData(RESOURCETYPE_BANK_GOLD, player->getBankBalance()); break;
 	case RESOURCETYPE_INVENTORY_GOLD: player->sendResourceData(RESOURCETYPE_INVENTORY_GOLD, player->getMoney()); break;
-	case RESOURCETYPE_PREY_BONUS_REROLLS: player->sendResourceData(RESOURCETYPE_PREY_BONUS_REROLLS, 0); break;
+	case RESOURCETYPE_PREY_BONUS_REROLLS: player->sendResourceData(RESOURCETYPE_PREY_BONUS_REROLLS, player->getBonusRerollCount()); break;
 	default: {
 		player->sendResourceData(RESOURCETYPE_BANK_GOLD, player->getBankBalance());
 		player->sendResourceData(RESOURCETYPE_INVENTORY_GOLD, player->getMoney());


### PR DESCRIPTION
Fix to issue #34

The method `playerRequestResourceData` was always returning 0 when the request was of the type `RESOURCETYPE_PREY_BONUS_REROLLS` not it returns the right amount of rerolls!