### PR TITLE
(fix/#58): bypass setStorageValue fn without storage value

### DIFF
--- a/data/lib/miscellaneous/050-functions.lua
+++ b/data/lib/miscellaneous/050-functions.lua
@@ -66,7 +66,9 @@ function clearForgotten(fromPosition, toPosition, exitPosition, storage)
 			end
 		end
 	end
-	Game.setStorageValue(storage, 0)
+	if storage then
+		Game.setStorageValue(storage, 0)
+	end
 end
 
 function getMoneyCount(string)


### PR DESCRIPTION
Issue #58 
Function clearForgotten with storage params required.
But, any time, call this function without storage params.

clearFogotten function
![image](https://github.com/Johncorex/otg-premium-version/assets/18264721/243ac552-887e-44e3-9a77-672d486a2d7d)

Any functions without storage on params (scenarios **WITH** errors on prompt)
![image](https://github.com/Johncorex/otg-premium-version/assets/18264721/6ba35dc5-88b8-4949-8ddf-f5eeb6f58345)

Function with all params filled (scenarios **WITHOUT** errors on prompt)
![image](https://github.com/Johncorex/otg-premium-version/assets/18264721/27887866-b7c4-4ab3-8676-506ac59d9265)

